### PR TITLE
feat(driver): add feature flags for display sizes and color modes

### DIFF
--- a/embd-tests/Cargo.toml
+++ b/embd-tests/Cargo.toml
@@ -27,3 +27,8 @@ bench = false
 name = "basic_panel"
 test = false
 bench = false
+
+[features]
+waveshare = ["hub75-rp2350-driver/waveshare_64x32"]
+128 = ["hub75-rp2350-driver/wtf_128x128"]
+64 = ["hub75-rp2350-driver/wtf_64x64"]

--- a/embd-tests/src/bin/basic_panel.rs
+++ b/embd-tests/src/bin/basic_panel.rs
@@ -159,8 +159,8 @@ async fn matrix_task(pio: Peri<'static, PIO0>, dma_channels: DmaChannels, pins: 
         // animations::stars::draw_animation_frame(&mut display, frame_counter).unwrap();
 
         // Alternative animations to try:
-        animations::fortytwo::draw_animation_frame(&mut display, frame_counter).unwrap();
-        // animations::fortytwo_rainbow::draw_animation_frame(&mut display, frame_counter).unwrap();
+        animations::arrow::draw_animation_frame(&mut display, frame_counter).unwrap();
+        // animations::fortytwo::draw_animation_frame(&mut display, frame_counter).unwrap();
         // display.draw_test_pattern();
 
         let anim_time = anim_start.elapsed();

--- a/hub75-rp2350-driver/Cargo.toml
+++ b/hub75-rp2350-driver/Cargo.toml
@@ -8,3 +8,13 @@ embedded-graphics-core = { workspace = true}
 embassy-rp = { workspace = true, features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp235xa"] }
 fixed-macro = "1.2.0"
 defmt = { workspace = true }
+
+[features]
+size_128x128 = []
+size_64x64 = []
+size_64x32 = []
+color_rgb = []
+color_gbr = []
+waveshare_64x32 = ["size_64x32", "color_rgb"]
+wtf_128x128 = ["size_128x128", "color_gbr"]
+wtf_64x64 = ["size_64x64", "color_gbr"]

--- a/hub75-rp2350-driver/src/config.rs
+++ b/hub75-rp2350-driver/src/config.rs
@@ -1,8 +1,13 @@
 //! Configuration constants and types for the Hub75 driver
 
 /// Display dimensions - must match your physical panel
-pub const DISPLAY_WIDTH: usize = 256;
-pub const DISPLAY_HEIGHT: usize = 64;
+pub const DISPLAY_WIDTH: usize = if cfg!(feature = "size_128x128") {
+    256
+} else {
+    64
+};
+
+pub const DISPLAY_HEIGHT: usize = if cfg!(feature = "size_64x32") { 32 } else { 64 };
 
 /// Number of rows that need to be addressed (dual-scan panels use half)
 pub const ACTIVE_ROWS: usize = DISPLAY_HEIGHT / 2; // 32 rows (requires 5 address bits)

--- a/hub75-rp2350-driver/src/lib.rs
+++ b/hub75-rp2350-driver/src/lib.rs
@@ -36,6 +36,30 @@
 
 #![no_std]
 
+#[cfg(not(any(
+    feature = "size_64x32",
+    feature = "size_64x64",
+    feature = "size_128x128"
+)))]
+compile_error!(
+    "A display size feature must be enabled. Choose one of: size_64x32, size_64x64, size_128x128"
+);
+
+#[cfg(not(any(feature = "color_rgb", feature = "color_gbr")))]
+compile_error!("a color order feature should be enabled. Choose one of: color_rgb, color_gbr");
+
+#[cfg(all(feature = "color_rgb", feature = "color_gbr"))]
+compile_error!("Cannot enable both color_rgb and color_gbr");
+
+#[cfg(all(feature = "size_64x32", feature = "size_64x64"))]
+compile_error!("Cannot enable both size_64x32 and size_64x64");
+
+#[cfg(all(feature = "size_64x32", feature = "size_128x128"))]
+compile_error!("Cannot enable both size_64x32 and size_128x128");
+
+#[cfg(all(feature = "size_64x64", feature = "size_128x128"))]
+compile_error!("Cannot enable both size_64x64 and size_128x128");
+
 pub mod config;
 pub mod dma;
 pub mod lut;

--- a/hub75-rp2350-driver/src/memory.rs
+++ b/hub75-rp2350-driver/src/memory.rs
@@ -98,9 +98,24 @@ impl DisplayMemory {
         let shift = if h { 3 } else { 0 };
 
         // CRITICAL: Original color channel mapping (swapped!)
-        let mut c_g: u16 = (((color.r() << 3) as f32) * (brightness as f32 / 255f32)) as u16;
-        let mut c_b: u16 = (((color.g() << 2) as f32) * (brightness as f32 / 255f32)) as u16;
-        let mut c_r: u16 = (((color.b() << 3) as f32) * (brightness as f32 / 255f32)) as u16;
+        let mut c_r: u16;
+        let mut c_b: u16;
+        let mut c_g: u16;
+
+        #[cfg(feature = "color_rgb")]
+        {
+            c_r = (((color.r() << 3) as f32) * (brightness as f32 / 255f32)) as u16;
+            c_g = (((color.g() << 2) as f32) * (brightness as f32 / 255f32)) as u16;
+            c_b = (((color.b() << 3) as f32) * (brightness as f32 / 255f32)) as u16;
+        }
+
+        #[cfg(feature = "color_gbr")]
+        {
+            c_g = (((color.r() << 3) as f32) * (brightness as f32 / 255f32)) as u16;
+            c_b = (((color.g() << 2) as f32) * (brightness as f32 / 255f32)) as u16;
+            c_r = (((color.b() << 3) as f32) * (brightness as f32 / 255f32)) as u16;
+        }
+
         let base_idx = x + ((y % (DISPLAY_HEIGHT / 2)) * DISPLAY_WIDTH * COLOR_BITS);
 
         c_r = GAMMA8[c_r as usize] as u16;


### PR DESCRIPTION
- Introduced feature flags (`color_rgb`, `color_gbr`, `size_64x32`, `size_64x64`, `size_128x128`) for configurable display size and color mappings.
- Added compile-time validations for mutually exclusive feature combinations.
- Updated brightness calculations for `color_rgb` and `color_gbr` support in `memory.rs`.
- Modified `basic_panel` to use the `arrow` animation.